### PR TITLE
Use new fallback config item

### DIFF
--- a/User/Install.ps1
+++ b/User/Install.ps1
@@ -18,8 +18,7 @@ if (Test-Path HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninst
         Start-Sleep -s 1
         }
     $configfile = Get-Content C:\ProgramData\Parsec\config.txt
-    $configfile += "host_virtual_monitors = 1"
-    $configfile += "host_privacy_mode = 1"
+    $configfile += "host_virtual_monitor_fallback = 1"
     $configfile | Out-File C:\ProgramData\Parsec\config.txt -Encoding ascii
     Copy-Item -Path "C:\ProgramData\Easy-GPU-P\Parsec.lnk" -Destination "C:\Users\Public\Desktop"
     Stop-Process parsecd -Force


### PR DESCRIPTION
Needs testing

In Parsec build 150-85, we added a feature to use our virtual display driver to create a fallback display, if the feature is enabled (disabled-by-default). 
This is a better solution that what this project currently does to enable the virtual displays, but I don't have the time to test it myself.

This should reliably create a virtual display to capture, but only if there are no other displays present.