### PR TITLE
Adds OpenGL and Vulkan support to Parsec Virtual Display Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ It's important to update the VM GPU Drivers after you have updated the Host GPUs
 - A powered on display / HDMI dummy dongle must be plugged into the GPU to allow Parsec to capture the screen.  You only need one of these per host machine regardless of number of VM's.
 - If your computer is super fast it may get to the login screen before the audio driver (VB Cable) and Parsec display driver are installed, but fear not! They should soon install.  
 - The screen may go black for times up to 10 seconds in situations when UAC prompts appear, applications go in and out of fullscreen and when you switch between video codecs in Parsec - not really sure why this happens, it's unique to GPU-P machines and seems to recover faster at 1280x720.
-- Vulkan renderer is unavailable and GL games may or may not work.  [This](https://www.microsoft.com/en-us/p/opencl-and-opengl-compatibility-pack/9nqpsl29bfff?SilentAuth=1&wa=wsignin1.0#activetab=pivot:overviewtab) may help with some OpenGL apps.  
 - If you do not have administrator permissions on the machine it means you set the username and vmname to the same thing, these needs to be different.  
 - AMD Polaris GPUS like the RX 580 do not support hardware video encoding via GPU Paravirtualization at this time.  
 - To download Windows ISOs with Rufus, it must have "Check for updates" enabled.

--- a/VMScripts/ParsecVDDInstall.ps1
+++ b/VMScripts/ParsecVDDInstall.ps1
@@ -1,5 +1,5 @@
 ﻿if (!(Get-WmiObject Win32_VideoController | Where-Object name -like "Parsec Virtual Display Adapter")) {
-(New-Object System.Net.WebClient).DownloadFile("https://builds.parsec.app/vdd/parsec-vdd-0.41.0.0.exe", "C:\Users\$env:USERNAME\Downloads\parsec-vdd.exe")
+(New-Object System.Net.WebClient).DownloadFile("https://builds.parsec.app/vdd/parsec-vdd-0.45.0.0.exe", "C:\Users\$env:USERNAME\Downloads\parsec-vdd.exe")
 while (((Get-ChildItem Cert:\LocalMachine\TrustedPublisher) | Where-Object {$_.Subject -like '*Parsec*'}) -eq $NULL) {
     certutil -Enterprise -Addstore "TrustedPublisher" C:\ProgramData\Easy-GPU-P\ParsecPublic.cer
     Start-Sleep -s 5

--- a/VMScripts/VDDMonitor.ps1
+++ b/VMScripts/VDDMonitor.ps1
@@ -1,4 +1,4 @@
-﻿$Global:VDD
+$Global:VDD
 
 Function GetVDDState {
 $Global:VDD = Get-PnpDevice | where {$_.friendlyname -like "Parsec Virtual Display Adapter"}
@@ -7,8 +7,12 @@ $Global:VDD = Get-PnpDevice | where {$_.friendlyname -like "Parsec Virtual Displ
 While (1 -gt 0) {
     GetVDDSTate
     If ($Global:VDD -eq $NULL){
-    Exit
-    }
+        Start-Sleep -s 10
+        }
+    If (!((Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services\ParsecVDA\Parameters\').PSObject.Properties.Name -contains "PreferredRenderAdapterVendorId")) {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services\ParsecVDA\Parameters\' -Name PreferredRenderAdapterVendorId -PropertyType DWORD -Value 5140 | Out-Null
+        Disable-PnpDevice -InstanceId $Global:VDD.InstanceId -Confirm:$false
+        }
     Do {
         Enable-PnpDevice -InstanceId $Global:VDD.InstanceId -Confirm:$false
         Start-Sleep -s 5


### PR DESCRIPTION
Updated Virtual Display Adapter to 0.45 and specified that the adapter attaches to the physical GPU.  

Tested Blender 4.0 (OpenGL) and Geeks3D GPU Caps Viewer (Vulkan and OpenGL).

GPU used for testing was Radeon RX 7900 XTX.