### PR TITLE
BitLocker support and ability to use alredy mounted drives

### DIFF
--- a/Update-VMGpuPartitionDriver.ps1
+++ b/Update-VMGpuPartitionDriver.ps1
@@ -1,4 +1,4 @@
-﻿<# 
+<# 
 If you are opening this file in Powershell ISE you should modify the params section like so...
 Remember: GPU Name must match the name of the GPU you assigned when creating the VM...
 
@@ -13,8 +13,11 @@ Param (
 Param (
 [string]$VMName,
 [string]$GPUName,
+[string]$BitLockerKey,
 [string]$Hostname = $ENV:Computername
 )
+
+$ErrorActionPreference = "Stop"
 
 Import-Module $PSSCriptRoot\Add-VMGpuPartitionAdapterFiles.psm1
 
@@ -22,21 +25,33 @@ $VM = Get-VM -VMName $VMName
 $VHD = Get-VHD -VMId $VM.VMId
 
 If ($VM.state -eq "Running") {
-    [bool]$state_was_running = $true
-    }
+    [bool]$state_was_running = $True
+}
 
 if ($VM.state -ne "Off"){
     "Attemping to shutdown VM..."
     Stop-VM -Name $VMName -Force
-    } 
+} 
 
 While ($VM.State -ne "Off") {
     Start-Sleep -s 3
     "Waiting for VM to shutdown - make sure there are no unsaved documents..."
-    }
+}
 
-"Mounting Drive..."
-$DriveLetter = (Mount-VHD -Path $VHD.Path -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+if ($VHD.Attached -eq $False) {
+    "Mounting Drive..."
+    $DriveLetter = (Mount-VHD -Path $VHD.Path -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+} else {
+    $DriveLetter = ($VHD | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+}
+
+$BitLockerStatus = Get-BitLockerVolume $DriveLetter
+if($BitLockerStatus.LockStatus) {
+    if([string]::IsNullOrWhiteSpace($BitLockerKey)){
+        $BitLockerKey = Read-Host "Enter BitLockerKey for drive $DriveLetter"
+    }
+    Unlock-BitLocker -MountPoint $DriveLetter -RecoveryPassword $BitLockerKey
+}
 
 "Copying GPU Files - this could take a while..."
 Add-VMGPUPartitionAdapterFiles -hostname $Hostname -DriveLetter $DriveLetter -GPUName $GPUName
@@ -44,9 +59,9 @@ Add-VMGPUPartitionAdapterFiles -hostname $Hostname -DriveLetter $DriveLetter -GP
 "Dismounting Drive..."
 Dismount-VHD -Path $VHD.Path
 
-If ($state_was_running){
+If ($state_was_running) {
     "Previous State was running so starting VM..."
     Start-VM $VMName
-    }
+}
 
 "Done..."


### PR DESCRIPTION
I made a few teaks to update GPU driver script.

1. Script will stop at first error,
2. If VHD of selected VM is already mounted, script will use it instead of mounting it again (which fails)
3. Added BitLocker support using recovery password (48 long) for software encrypted VHD partitions.